### PR TITLE
Building docker image using docker api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Webhook Config
-WEBHOOK_SECRET=abcd
+WEBHOOK_SECRET=
 FILTER_WEBHOOKS=
 
 # Slack
 # Leave SLACK empty if you want this to be false, otherwise set to `True` (https://dev.to/nicolaerario/comment/fe1e)
-SLACK=
+SLACK=True
 SLACK_CHANNEL=
 SLACK_BOT_TOKEN=
 

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Webhook Config
-WEBHOOK_SECRET=
+WEBHOOK_SECRET=abcd
 FILTER_WEBHOOKS=
 
 # Slack
 # Leave SLACK empty if you want this to be false, otherwise set to `True` (https://dev.to/nicolaerario/comment/fe1e)
-SLACK=True
+SLACK=
 SLACK_CHANNEL=
 SLACK_BOT_TOKEN=
 

--- a/harvey/images.py
+++ b/harvey/images.py
@@ -2,66 +2,68 @@ import os
 import subprocess
 
 import requests
+import docker
 
 from harvey.globals import Global
 
 
 class Image:
     @staticmethod
-    def build_image(config, webhook, context=''):
+    def build_image(config, webhook, context=""):
         """Build a Docker image by shelling out and running Docker commands."""
-        # TODO: Use the Docker API for building instead of a shell \
-        # command (haven't because I can't get it working)
         # tar = open('./docker/pullbug.tar.gz', encoding="latin-1").read()
         # json = open('./harvey/build.json', 'rb').read()
         # data = requests.post(Global.BASE_URL + 'build', \
         # params=json, data=tar, headers=Global.TAR_HEADERS)
 
         # Set variables based on the context (test vs deploy vs full)
-        if context == 'test':
-            language = f'--build-arg LANGUAGE={config.get("language", "")}'
-            version = f'--build-arg VERSION={config.get("version", "")}'
-            project = f'--build-arg PROJECT={Global.repo_full_name(webhook)}'
-            path = f'{Global.PROJECTS_PATH}'
+        if context == "test":
+            language = config.get("language", "")
+            version = config.get("version", "")
+            project = Global.repo_full_name(webhook)
+            path = Global.PROJECTS_PATH
         else:
-            language = ''
-            version = ''
-            project = ''
+            language = ""
+            version = ""
+            project = ""
             path = os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook))
-        dockerfile = f'-f {config["dockerfile"]}' if config.get("dockerfile") else ''
-        tag_arg = f'-t {Global.docker_project_name(webhook)}'
+        dockerfile = config["dockerfile"] if config.get("dockerfile") else ""
+        tag_arg = Global.docker_project_name(webhook)
 
         # Build the image (exceptions bubble up to the stage module)
-        # We cd into the directory here so we have access to the files to copy into the container
-        image = subprocess.check_output(
-            f'cd {path} && docker build {dockerfile} {tag_arg} {language} {version} {project} .',
-            stdin=None,
-            stderr=None,
-            shell=True,
-            timeout=Global.BUILD_TIMEOUT,
+        client = docker.from_env()
+        image = client.images.build(
+            path=path,
+            tag=tag_arg,
+            buildargs={
+                "LANGUAGE": language,
+                "VERSION": version,
+                "PROJECT": project,
+            },
         )
 
-        return image.decode('UTF-8')
+        # Returns TAG of image
+        return image.tags[0]
 
     @staticmethod
     def retrieve_image(image_id):
         """Retrieve a Docker image."""
-        response = requests.get(Global.BASE_URL + f'images/{image_id}/json')
+        response = requests.get(Global.BASE_URL + f"images/{image_id}/json")
         return response
 
     @staticmethod
     def retrieve_all_images():
         """Retrieve all Docker images"""
-        response = requests.get(Global.BASE_URL + 'images/json')
+        response = requests.get(Global.BASE_URL + "images/json")
         return response
 
     @staticmethod
     def remove_image(image_id):
         """Remove (delete) a Docker image."""
         response = requests.delete(
-            Global.BASE_URL + f'images/{image_id}',
+            Global.BASE_URL + f"images/{image_id}",
             json={
-                'force': True,
+                "force": True,
             },
             headers=Global.JSON_HEADERS,
         )

--- a/harvey/images.py
+++ b/harvey/images.py
@@ -37,7 +37,7 @@ class Image:
             timeout=Global.BUILD_TIMEOUT
         )
 
-        return image.tags[0]
+        return image[0].id
 
     @staticmethod
     def retrieve_image(image_id):

--- a/harvey/images.py
+++ b/harvey/images.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import requests
 import docker
@@ -9,25 +8,20 @@ from harvey.globals import Global
 
 class Image:
     @staticmethod
-    def build_image(config, webhook, context=""):
-        """Build a Docker image by shelling out and running Docker commands."""
-        # tar = open('./docker/pullbug.tar.gz', encoding="latin-1").read()
-        # json = open('./harvey/build.json', 'rb').read()
-        # data = requests.post(Global.BASE_URL + 'build', \
-        # params=json, data=tar, headers=Global.TAR_HEADERS)
-
+    def build_image(config, webhook, context=''):
+        """Build a Docker image using docker-py."""
         # Set variables based on the context (test vs deploy vs full)
-        if context == "test":
+        if context == 'test':
             language = config.get("language", "")
             version = config.get("version", "")
             project = Global.repo_full_name(webhook)
             path = Global.PROJECTS_PATH
         else:
-            language = ""
-            version = ""
-            project = ""
+            language = ''
+            version = ''
+            project = ''
             path = os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook))
-        dockerfile = config["dockerfile"] if config.get("dockerfile") else ""
+        # dockerfile = config["dockerfile"] if config.get("dockerfile") else ''
         tag_arg = Global.docker_project_name(webhook)
 
         # Build the image (exceptions bubble up to the stage module)
@@ -40,30 +34,30 @@ class Image:
                 "VERSION": version,
                 "PROJECT": project,
             },
+            timeout=Global.BUILD_TIMEOUT
         )
 
-        # Returns TAG of image
         return image.tags[0]
 
     @staticmethod
     def retrieve_image(image_id):
         """Retrieve a Docker image."""
-        response = requests.get(Global.BASE_URL + f"images/{image_id}/json")
+        response = requests.get(Global.BASE_URL + f'images/{image_id}/json')
         return response
 
     @staticmethod
     def retrieve_all_images():
         """Retrieve all Docker images"""
-        response = requests.get(Global.BASE_URL + "images/json")
+        response = requests.get(Global.BASE_URL + 'images/json')
         return response
 
     @staticmethod
     def remove_image(image_id):
         """Remove (delete) a Docker image."""
         response = requests.delete(
-            Global.BASE_URL + f"images/{image_id}",
+            Global.BASE_URL + f'images/{image_id}',
             json={
-                "force": True,
+                'force': True,
             },
             headers=Global.JSON_HEADERS,
         )

--- a/harvey/stages.py
+++ b/harvey/stages.py
@@ -9,6 +9,7 @@ from harvey.images import Image
 from harvey.utils import Utils
 import multiprocessing
 
+
 class TestStage:
     @staticmethod
     def run(config, webhook, output):
@@ -33,7 +34,7 @@ class TestStage:
             image.start()
             image.join(Global.BUILD_TIMEOUT)
             if image.is_alive():
-                p.terminate()
+                image.terminate()
                 raise multiprocessing.TimeoutError
             image_output = f'Test image created.\n{image}'
             print(image_output)

--- a/harvey/utils.py
+++ b/harvey/utils.py
@@ -34,7 +34,7 @@ class Logs:
             os.makedirs(os.path.join(Global.PROJECTS_LOG_PATH, Global.repo_full_name(webhook)))
         try:
             filename = os.path.join(
-                Global.PROJECTS_LOG_PATH, Global.repo_full_name(webhook), Global.repo_commit_id(webhook) + '.log'
+                Global.PROJECTS_LOG_PATH, Global.repo_full_name(webhook), str(Global.repo_commit_id(webhook)) + '.log'
             )
             with open(filename, 'w') as log:
                 log.write(final_output)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ REQUIREMENTS = [
     'requests_unixsocket == 0.2.*',
     'slackclient == 2.*',
     'python-dotenv == 0.17.*',
-    'docker'
+    'docker',
+    'six', # Docker dependency, but not sure why not being install with docker
 ]
 
 DEV_REQUIREMENTS = [
@@ -18,7 +19,8 @@ DEV_REQUIREMENTS = [
     'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
-    'docker'
+    'docker',
+    'six',
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ REQUIREMENTS = [
     'requests_unixsocket == 0.2.*',
     'slackclient == 2.*',
     'python-dotenv == 0.17.*',
+    'docker'
 ]
 
 DEV_REQUIREMENTS = [
@@ -17,6 +18,7 @@ DEV_REQUIREMENTS = [
     'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
+    'docker'
 ]
 
 setuptools.setup(

--- a/test/unit/test_images.py
+++ b/test/unit/test_images.py
@@ -6,10 +6,10 @@ from harvey.globals import Global
 from harvey.images import Image
 from docker.models.images import ImageCollection
 
+
 @pytest.mark.parametrize('context', [('test'), (None)])
 @mock.patch.object(ImageCollection, 'build')
 def test_build_image(mock_build, context, mock_webhook):
-    # TODO: Mock the subprocess better to ensure it does what it's supposed to
     Image.build_image(
         {
             'pipeline': 'full',

--- a/test/unit/test_images.py
+++ b/test/unit/test_images.py
@@ -4,11 +4,11 @@ import mock
 import pytest
 from harvey.globals import Global
 from harvey.images import Image
-
+from docker.models.images import ImageCollection
 
 @pytest.mark.parametrize('context', [('test'), (None)])
-@mock.patch('subprocess.check_output')
-def test_build_image(mock_subprocess, context, mock_webhook):
+@mock.patch.object(ImageCollection, 'build')
+def test_build_image(mock_build, context, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     Image.build_image(
         {
@@ -20,7 +20,7 @@ def test_build_image(mock_subprocess, context, mock_webhook):
         context
     )
 
-    mock_subprocess.assert_called_once()
+    mock_build.assert_called_once()
 
 
 @mock.patch('requests.get', return_value=mock_response(201))

--- a/test/unit/test_stages.py
+++ b/test/unit/test_stages.py
@@ -1,9 +1,8 @@
 import subprocess
-from docker.models.images import ImageCollection
 from test.unit.conftest import mock_config  # Remove once fixtures are fixed
 from test.unit.conftest import mock_response_container
 import multiprocessing
-from multiprocessing.process import BaseProcess
+
 
 import mock
 from harvey.globals import Global
@@ -14,10 +13,11 @@ MOCK_OUTPUT = 'mock output'
 
 @mock.patch('harvey.images.Image.remove_image')
 @mock.patch('multiprocessing.Process')
-@mock.patch('harvey.utils.Utils.kill') # Need to add this not able to patch process.is_alive()
+@mock.patch('harvey.utils.Utils.kill')
 def test_build_stage_success(mock_kill, mock_build, mock_remove_image, mock_webhook):
+    # TODO: Mock process.is_alive() so that we can remove mocking of Utils.kill
     _ = BuildStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
-    mock_build.is_alive.return_value = False
+
     mock_remove_image.assert_called_once()
     mock_build.assert_called_once()
 
@@ -35,7 +35,6 @@ def test_build_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_r
 @mock.patch('harvey.images.Image.remove_image')
 @mock.patch('harvey.utils.Utils.kill')
 @mock.patch('multiprocessing.Process', side_effect=multiprocessing.TimeoutError)
-# @mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
 def test_build_stage_process_error(mock_subprocess, mock_utils_kill, mock_remove_image, mock_project_path, mock_webhook):  # noqa
     _ = BuildStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 


### PR DESCRIPTION
Changing the image build process to use docker API.
Changes Made to 
1. harvey/images.py
    Changing variables to the values only rather than making them command-line arguments that are run through subprocess.
    Under if condition for context == 'test'
    i. We are changing the language variable to the value of the language key provided in config dictionary, same procedure is 
    followed for variables version and project.
    ii. We are changing tag_arg variable to get the tag for the image from the webhook.
    iii. Initiating docker client, for now I have only allowed to use docker on host machine.
        (I am not sure but I think harvey has no support to connect to docker on other machines to build images or run containers)
    iv. Lastly, we are creating the image using image.build method. Now we don't have to cd into the directory as we have 
    provided the path for dockerfile as parameter to the method and then we are returning the tag of newly created image.


2. test/unit/test_images.py
    1. We also have to change the test_build_image method as now no subprocess is being run. So we are mocking the build 
        object (https://stackoverflow.com/questions/64089226/how-to-mock-call-to-python-docker-sdk-using-mockito)

I'll change the double quotes to single quotes.
Also, clean up the docstrings and comments and I'll also add docker to setup.py.

I only ran tests for test_images.py, I'll make sure to run and pass other tests as well.

**These are just suggestions feel free to reject if these changes don't seem to go with the project.**