### PR TITLE
feat: user-specific ALLOWED_BRANCHES and webhook fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Webhook Config
+ALLOWED_BRANCHES="main,master"
 WEBHOOK_SECRET=
 FILTER_WEBHOOKS=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## NEXT RELEASE
 
 * Corrects encoding of test logs, binary data should no longer show in the output (closes #4)
+* Overhauls the webhook flow
+    * Users can now configure their own comma separated list of `ALLOWED_BRANCHES`
+    * Previously a webhook secret was required; now, Harvey will run Pipelines without a webhook secret (bypassing decoding and validation of the previously non-existent secret) if there is no `WEBHOOK_SECRET` variable set
+    * Additional refactor surrounding how we validate webhook secrets
+
 * Various code refactors
 
 ## v0.12.0 (2021-08-17)

--- a/README.md
+++ b/README.md
@@ -98,15 +98,16 @@ Harvey's entrypoint (eg: `127.0.0.1:5000/pipelines/start`) accepts a webhook fro
 
 ```
 Environment Variables:
-    SLACK           Set to "true" to send slack messages
-    SLACK_CHANNEL   The Slack channel to send messages to
-    SLACK_BOT_TOKEN The Slackbot token to use to authenticate each request to Slack
-    WEBHOOK_SECRET  The Webhook secret required by GitHub (if enabled) to secure your webhooks
-    FILTER_WEBHOOKS Setting this to `true` will filter webhooks and only accept those from GitHub's list of webhook IP ranges. Default: False
-    MODE            Set to "test" to bypass the header and auth data from GitHub to test. Default: production
-    HOST            The host Harvey will run on. Default: 127.0.0.1
-    PORT            The port Harvey will run on. Default: 5000
-    DEBUG           Whether the Flask API will run in debug mode or not
+    SLACK             Set to "true" to send slack messages
+    SLACK_CHANNEL     The Slack channel to send messages to
+    SLACK_BOT_TOKEN   The Slackbot token to use to authenticate each request to Slack
+    WEBHOOK_SECRET    The Webhook secret required by GitHub (if enabled, leave blank to ignore) to secure your webhooks. Default: disabled
+    FILTER_WEBHOOKS   Setting this to `true` will filter webhooks and only accept those from GitHub's list of webhook IP ranges. Default: False
+    MODE              Set to "test" to bypass the header and auth data from GitHub to test. Default: production
+    HOST              The host Harvey will run on. Default: 127.0.0.1
+    PORT              The port Harvey will run on. Default: 5000
+    DEBUG             Whether the Flask API will run in debug mode or not
+    ALLOWED_BRANCHES  A comma separated list of branch names that are allowed to trigger pipelines from a webhook event. Default: "main,master"
 ```
 
 ### Example Python Functions

--- a/harvey/globals.py
+++ b/harvey/globals.py
@@ -16,10 +16,7 @@ class Global:
     TAR_HEADERS = {'Content-Type': 'application/tar'}
     APP_MODE = os.getenv('MODE', 'production').lower()
     FILTER_WEBHOOKS = os.getenv('FILTER_WEBHOOKS', False)
-    ALLOWED_BRANCHES = [
-        'refs/heads/master',
-        'refs/heads/main',
-    ]
+    ALLOWED_BRANCHES = [branch.strip().lower() for branch in os.getenv('ALLOWED_BRANCHES', 'main,master').split(',')]
     SUPPORTED_PIPELINES = [
         'pull',
         'test',

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -9,36 +9,37 @@ def mock_client():
 
 
 @pytest.fixture
-def mock_webhook(branch='refs/heads/main'):
+def mock_webhook(branch='main'):
     return {
-        "ref": branch,
+        "ref": f'refs/heads/{branch}',
         "repository": {
             "name": "TEST-repo-name",
             "full_name": "TEST_user/TEST-repo-name",
             "ssh_url": "https://test-url.com",
             "owner": {
-                    "name": "TEST_owner"
-            }
+                "name": "TEST_owner",
+            },
         },
         "commits": [
             {
                 "id": 123456,
                 "author": {
-                    "name": "test_user"
-                }
+                    "name": "test_user",
+                },
             }
-        ]
+        ],
     }
 
 
 @pytest.fixture
-def mock_webhook_object(branch='refs/heads/main'):
+def mock_webhook_object(branch='main'):
     webhook = mock.MagicMock()
+    webhook.remote_addr = '192.30.252.0'  # A real GitHub IP address
     webhook.json = {
-        "ref": branch,
+        "ref": f'refs/heads/{branch}',
         "repository": {
             "name": "TEST-repo-name",
-        }
+        },
     }
     return webhook
 
@@ -62,7 +63,7 @@ def mock_project_path():
 def mock_response(status=201, json_data={'mock': 'json'}):
     response = mock.MagicMock()
     response.json = mock.MagicMock(
-        return_value=json_data
+        return_value=json_data,
     )
     response.status_code = status
     return response
@@ -87,7 +88,7 @@ def mock_response_container(status=200, dead=False, paused=False, restarting=Fal
                 'Dead': dead,
                 'Paused': paused,
                 'Restarting': restarting,
-                'Running': running
+                'Running': running,
             }
         }
     )

--- a/test/unit/test_webhooks.py
+++ b/test/unit/test_webhooks.py
@@ -12,7 +12,7 @@ def test_parse_webhook(mock_start_pipeline, mock_webhook_object):
 
     assert webhook[0] == {
         'message': 'Started pipeline for TEST-repo-name',
-        'success': True
+        'success': True,
     }
     assert webhook[1] == 200
 
@@ -23,8 +23,8 @@ def test_parse_webhook_bad_branch(mock_start_pipeline, mock_webhook_object):
     webhook = Webhook.parse_webhook(mock_webhook_object(branch='ref/heads/bad_branch'), False)
 
     assert webhook[0] == {
-        'message': 'Harvey can only pull from the "master" or "main" branch of a repo.',
-        'success': False
+        'message': 'Harvey received a webhook event for a branch that is not included in the ALLOWED_BRANCHES.',
+        'success': False,
     }
     assert webhook[1] == 422
 
@@ -38,12 +38,13 @@ def test_parse_webhook_no_json(mock_start_pipeline):
 
     assert webhook[0] == {
         'message': 'Malformed or missing JSON data in webhook.',
-        'success': False
+        'success': False,
     }
     assert webhook[1] == 422
 
 
-@mock.patch('harvey.webhooks.Webhook.decode_webhook', return_value=False)
+@mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
+@mock.patch('harvey.webhooks.Webhook.validate_webhook_secret', return_value=False)
 @mock.patch('harvey.globals.Global.APP_MODE', 'prod')
 @mock.patch('harvey.webhooks.Pipeline.start_pipeline')
 def test_parse_webhook_bad_webhook_secret(mock_start_pipeline, mock_webhook_object):
@@ -51,23 +52,36 @@ def test_parse_webhook_bad_webhook_secret(mock_start_pipeline, mock_webhook_obje
 
     assert webhook[0] == {
         'message': 'The X-Hub-Signature did not match the WEBHOOK_SECRET.',
-        'success': False
+        'success': False,
     }
     assert webhook[1] == 403
 
 
 @mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
 @mock.patch('harvey.webhooks.APP_MODE', 'prod')
-@pytest.mark.skip('Security is hard, revisit later - but this logic does work')
-def test_decode_webhook(mock_webhook):
+@pytest.mark.skip('Security is hard, revisit later - this logic has been proven in prod')
+def test_validate_webhook_secret(mock_webhook):
     mock_webhook_secret = bytes('123', 'UTF-8')
     mock_signature = hashlib.sha1(mock_webhook_secret)
-    decoded_webhook = Webhook.decode_webhook(mock_webhook, mock_signature)
+    validated_webhook_secret = Webhook.validate_webhook_secret(mock_webhook, mock_signature)
 
-    assert decoded_webhook is True
+    assert validated_webhook_secret is True
 
 
-def test_decode_webhook_no_signature(mock_webhook):
-    decoded_webhook = Webhook.decode_webhook(mock_webhook, None)
+@mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
+def test_validate_webhook_secret_no_signature(mock_webhook):
+    validated_webhook_secret = Webhook.validate_webhook_secret(mock_webhook, None)
 
-    assert decoded_webhook is False
+    assert validated_webhook_secret is False
+
+
+@mock.patch('harvey.globals.Global.FILTER_WEBHOOKS', True)
+def test_webhook_originated_outside_github(mock_webhook_object):
+    mock_webhook_object.remote_addr = '1.2.3.4'
+    webhook = Webhook.parse_webhook(mock_webhook_object, False)
+
+    assert webhook[0] == {
+        'message': 'Webhook did not originate from GitHub.',
+        'success': False,
+    }
+    assert webhook[1] == 422


### PR DESCRIPTION
* Overhauls the webhook flow
    * Users can now configure their own comma separated list of `ALLOWED_BRANCHES`
    * Previously a webhook secret was required; now, Harvey will run Pipelines without a webhook secret (bypassing decoding and validation of the previously non-existent secret) if there is no `WEBHOOK_SECRET` variable set
    * Additional refactor surrounding how we validate webhook secrets