### PR TITLE
chore: bump deps and remove mock library

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 120
+extend-ignore = E203

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     * Previously a webhook secret was required; now, Harvey will run Pipelines without a webhook secret (bypassing decoding and validation of the previously non-existent secret) if there is no `WEBHOOK_SECRET` variable set
     * Additional refactor surrounding how we validate webhook secrets
 * Fixed the container healthcheck when using the compose workflow - this was accomplished by making the compose and non-compose container names uniform
+* Bumps dependencies (Flask 1 to Flask 2) and now required Python 3.7. Also removes the `mock` library in favor of the builtin `unittest.mock` library
 * Various code refactors and bug fixes
 
 ## v0.12.0 (2021-08-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     * Previously a webhook secret was required; now, Harvey will run Pipelines without a webhook secret (bypassing decoding and validation of the previously non-existent secret) if there is no `WEBHOOK_SECRET` variable set
     * Additional refactor surrounding how we validate webhook secrets
 * Fixed the container healthcheck when using the compose workflow - this was accomplished by making the compose and non-compose container names uniform
-* Bumps dependencies (Flask 1 to Flask 2) and now required Python 3.7. Also removes the `mock` library in favor of the builtin `unittest.mock` library
+* Bumps dependencies (Flask 1 to Flask 2) and now requires Python 3.7. Also removes the `mock` library in favor of the builtin `unittest.mock` library
 * Various code refactors and bug fixes
 
 ## v0.12.0 (2021-08-17)

--- a/harvey/pipelines.py
+++ b/harvey/pipelines.py
@@ -107,8 +107,8 @@ class Pipeline:
         # within a JSON file in the repo
         try:
             filename = os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook), 'harvey.json')
-            with open(filename, 'r') as file:
-                config = json.loads(file.read())
+            with open(filename, 'r') as config_file:
+                config = json.loads(config_file.read())
                 print(json.dumps(config, indent=4))
             return config
         except FileNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,16 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 REQUIREMENTS = [
-    'flask == 1.*',  # TODO: bump to v2 after thorough testing
+    'flask == 2.*',
     'requests == 2.*',
     'requests_unixsocket == 0.2.*',
     'slackclient == 2.*',
-    'python-dotenv == 0.17.*',
+    'python-dotenv == 0.19.*',
 ]
 
 DEV_REQUIREMENTS = [
     'coveralls == 3.*',
     'flake8',
-    'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
 ]
@@ -41,5 +40,5 @@ setuptools.setup(
     entry_points={
         'console_scripts': ['harvey-ci=harvey.app:main'],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, Mock
+
 import harvey.app as app
-import mock
 import pytest
 
 
@@ -33,7 +34,7 @@ def mock_webhook(branch='main'):
 
 @pytest.fixture
 def mock_webhook_object(branch='main'):
-    webhook = mock.MagicMock()
+    webhook = MagicMock()
     webhook.remote_addr = '192.30.252.0'  # A real GitHub IP address
     webhook.json = {
         "ref": f'refs/heads/{branch}',
@@ -61,8 +62,8 @@ def mock_project_path():
 
 # TODO: Move this to a fixture
 def mock_response(status=201, json_data={'mock': 'json'}):
-    response = mock.MagicMock()
-    response.json = mock.MagicMock(
+    response = MagicMock()
+    response.json = MagicMock(
         return_value=json_data,
     )
     response.status_code = status
@@ -81,8 +82,8 @@ def mock_config(pipeline='deploy', language='python', version='3.9', compose=Non
 
 # TODO: Move this to a fixture
 def mock_response_container(status=200, dead=False, paused=False, restarting=False, running=True):
-    response = mock.Mock()
-    response.json = mock.Mock(
+    response = Mock()
+    response.json = Mock(
         return_value={
             'State': {
                 'Dead': dead,

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -1,5 +1,5 @@
 import harvey.app as app
-import mock
+from unittest.mock import patch
 import pytest
 
 
@@ -17,7 +17,7 @@ def test_routes_are_reachable_get(mock_client, route):
     assert response.status_code == 200
 
 
-@mock.patch('harvey.webhooks.Webhook.parse_webhook')
+@patch('harvey.webhooks.Webhook.parse_webhook')
 def test_start_pipeline(mock_parse_webhook):
     # TODO: Long-term, test the status_code and logic
     app.start_pipeline()
@@ -25,7 +25,7 @@ def test_start_pipeline(mock_parse_webhook):
     mock_parse_webhook.assert_called_once()
 
 
-@mock.patch('harvey.webhooks.Webhook.parse_webhook')
+@patch('harvey.webhooks.Webhook.parse_webhook')
 def test_start_pipeline_compose(mock_parse_webhook):
     # TODO: Long-term, test the status_code and logic
     app.start_pipeline_compose()

--- a/test/unit/test_containers.py
+++ b/test/unit/test_containers.py
@@ -1,11 +1,11 @@
 from test.unit.conftest import mock_response  # Remove once fixtures are fixed
+from unittest.mock import patch
 
-import mock
 from harvey.containers import Container
 from harvey.globals import Global
 
 
-@mock.patch('requests.post', return_value=mock_response(status=201))
+@patch('requests.post', return_value=mock_response(status=201))
 def test_create_container(mock_request, mock_tag):
     container = Container.create_container(mock_tag)
 
@@ -13,13 +13,13 @@ def test_create_container(mock_request, mock_tag):
         f'{Global.BASE_URL}containers/create',
         params={'name': mock_tag},
         json={'Image': mock_tag},
-        headers=Global.JSON_HEADERS
+        headers=Global.JSON_HEADERS,
     )
     assert container.json() == {'mock': 'json'}
     assert container.status_code == 201
 
 
-@mock.patch('requests.post', return_value=mock_response(status=204))
+@patch('requests.post', return_value=mock_response(status=204))
 def test_start_container(mock_request, mock_tag):
     container = Container.start_container(mock_tag)
 
@@ -28,7 +28,7 @@ def test_start_container(mock_request, mock_tag):
     assert container.status_code == 204
 
 
-@mock.patch('requests.post', return_value=mock_response(status=204))
+@patch('requests.post', return_value=mock_response(status=204))
 def test_stop_container(mock_request, mock_tag):
     container = Container.stop_container(mock_tag)
 
@@ -37,7 +37,7 @@ def test_stop_container(mock_request, mock_tag):
     assert container.status_code == 204
 
 
-@mock.patch('requests.get', return_value=mock_response(status=200))
+@patch('requests.get', return_value=mock_response(status=200))
 def test_inspect_container(mock_request, mock_tag):
     container = Container.inspect_container(mock_tag)
 
@@ -46,7 +46,7 @@ def test_inspect_container(mock_request, mock_tag):
     assert container.status_code == 200
 
 
-@mock.patch('requests.get', return_value=mock_response(status=200))
+@patch('requests.get', return_value=mock_response(status=200))
 def test_list_containers(mock_request, mock_tag):
     container = Container.list_containers()
 
@@ -55,17 +55,17 @@ def test_list_containers(mock_request, mock_tag):
     assert container.status_code == 200
 
 
-@mock.patch('requests.get', return_value=mock_response(status=200))
+@patch('requests.get', return_value=mock_response(status=200))
 def test_inspect_container_logs(mock_request):
     Container.inspect_container_logs(1)
 
     mock_request.assert_called_once_with(
         f'{Global.BASE_URL}containers/1/logs',
-        params={'stdout': True, 'stderr': True}
+        params={'stdout': True, 'stderr': True},
     )
 
 
-@mock.patch('requests.post', return_value=mock_response(status=200))
+@patch('requests.post', return_value=mock_response(status=200))
 def test_wait_container(mock_request, mock_tag):
     container = Container.wait_container(mock_tag)
 
@@ -74,14 +74,14 @@ def test_wait_container(mock_request, mock_tag):
     assert container.status_code == 200
 
 
-@mock.patch('requests.delete', return_value=mock_response(status=204))
+@patch('requests.delete', return_value=mock_response(status=204))
 def test_remove_container(mock_request, mock_tag):
     container = Container.remove_container(mock_tag)
 
     mock_request.assert_called_once_with(
         f'{Global.BASE_URL}containers/{mock_tag}',
         json={'force': True},
-        headers=Global.JSON_HEADERS
+        headers=Global.JSON_HEADERS,
     )
     assert container.json() == {'mock': 'json'}
     assert container.status_code == 204

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -1,26 +1,26 @@
 import subprocess
+from unittest.mock import patch
 
-import mock
 from harvey.git import Git
 
 
-@mock.patch('os.path.exists', return_value=True)
-@mock.patch('harvey.git.Git.pull_repo')
+@patch('os.path.exists', return_value=True)
+@patch('harvey.git.Git.pull_repo')
 def test_update_git_repo_path_exists(mock_pull_repo, mock_path_exists, mock_project_path, mock_webhook):  # noqa
     Git.update_git_repo(mock_webhook)
 
     mock_pull_repo.assert_called_once_with(mock_project_path, mock_webhook)
 
 
-@mock.patch('os.path.exists', return_value=False)
-@mock.patch('harvey.git.Git.clone_repo')
-def test_update_git_repo_path_does_not_exist(mock_clone_repo, mock_path_exists, mock_project_path, mock_webhook):  # noqa
+@patch('os.path.exists', return_value=False)
+@patch('harvey.git.Git.clone_repo')
+def test_update_git_repo_path_does_not_exist(mock_clone_repo, mock_path_exists, mock_project_path, mock_webhook):
     Git.update_git_repo(mock_webhook)
 
     mock_clone_repo.assert_called_once_with(mock_project_path, mock_webhook)
 
 
-@mock.patch('subprocess.check_output')
+@patch('subprocess.check_output')
 def test_clone_repo(mock_subprocess, mock_project_path, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     Git.clone_repo(mock_project_path, mock_webhook)
@@ -28,23 +28,23 @@ def test_clone_repo(mock_subprocess, mock_project_path, mock_webhook):
     mock_subprocess.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))  # noqa
-def test_clone_repo_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))
+def test_clone_repo_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
     Git.clone_repo(mock_project_path, mock_webhook)
 
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
-def test_clone_repo_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))
+def test_clone_repo_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
     Git.clone_repo(mock_project_path, mock_webhook)
 
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('subprocess.check_output')
+@patch('subprocess.check_output')
 def test_pull_repo(mock_subprocess, mock_project_path, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     Git.pull_repo(mock_project_path, mock_webhook)
@@ -52,17 +52,17 @@ def test_pull_repo(mock_subprocess, mock_project_path, mock_webhook):
     mock_subprocess.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))  # noqa
-def test_pull_repo_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))
+def test_pull_repo_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
     Git.pull_repo(mock_project_path, mock_webhook)
 
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
-def test_pull_repo_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))
+def test_pull_repo_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
     Git.pull_repo(mock_project_path, mock_webhook)
 
     mock_utils_kill.assert_called_once()

--- a/test/unit/test_images.py
+++ b/test/unit/test_images.py
@@ -1,13 +1,13 @@
 from test.unit.conftest import mock_response  # Remove once fixtures are fixed
+from unittest.mock import patch
 
-import mock
 import pytest
 from harvey.globals import Global
 from harvey.images import Image
 
 
-@pytest.mark.parametrize('context', [('test'), (None)])
-@mock.patch('subprocess.check_output')
+@pytest.mark.parametrize('context', ['test', (None)])
+@patch('subprocess.check_output')
 def test_build_image(mock_subprocess, context, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     Image.build_image(
@@ -17,32 +17,32 @@ def test_build_image(mock_subprocess, context, mock_webhook):
             'version': '3.9',
         },
         mock_webhook,
-        context
+        context,
     )
 
     mock_subprocess.assert_called_once()
 
 
-@mock.patch('requests.get', return_value=mock_response(201))
+@patch('requests.get', return_value=mock_response(201))
 def test_retrieve_image(mock_request):
     Image.retrieve_image(1)
 
     mock_request.assert_called_once_with(Global.BASE_URL + 'images/1/json')
 
 
-@mock.patch('requests.get', return_value=mock_response(201))
+@patch('requests.get', return_value=mock_response(201))
 def test_retrieve_all_images(mock_request):
     Image.retrieve_all_images()
 
     mock_request.assert_called_once_with(Global.BASE_URL + 'images/json')
 
 
-@mock.patch('requests.delete', return_value=mock_response(201))
+@patch('requests.delete', return_value=mock_response(201))
 def test_remove_image(mock_request):
     Image.remove_image(1)
 
     mock_request.assert_called_once_with(
         Global.BASE_URL + 'images/1',
         json={'force': True},
-        headers=Global.JSON_HEADERS
+        headers=Global.JSON_HEADERS,
     )

--- a/test/unit/test_messages.py
+++ b/test/unit/test_messages.py
@@ -1,12 +1,13 @@
-import mock
+from unittest.mock import patch
+
 import pytest
 import slack
 from harvey.messages import Message
 
 
-@mock.patch('harvey.messages.SLACK_CHANNEL', 'mock-channel')
-@mock.patch('harvey.messages.SLACK_BOT_TOKEN', '123')
-@mock.patch('slack.WebClient.chat_postMessage')
+@patch('harvey.messages.SLACK_CHANNEL', 'mock-channel')
+@patch('harvey.messages.SLACK_BOT_TOKEN', '123')
+@patch('slack.WebClient.chat_postMessage')
 def test_send_slack_message_success(mock_slack):
     message = 'mock message'
     Message.send_slack_message(message)
@@ -14,12 +15,17 @@ def test_send_slack_message_success(mock_slack):
     mock_slack.assert_called_once_with(channel='mock-channel', text=message)
 
 
-@mock.patch('sys.exit')
-@mock.patch('slack.WebClient.chat_postMessage',
-            side_effect=slack.errors.SlackApiError(
-                message='The request to the Slack API failed.',
-                response={'ok': False, 'error': 'not_authed'}
-            ))
+@patch('sys.exit')
+@patch(
+    'slack.WebClient.chat_postMessage',
+    side_effect=slack.errors.SlackApiError(
+        message='The request to the Slack API failed.',
+        response={
+            'ok': False,
+            'error': 'not_authed',
+        },
+    ),
+)
 def test_send_slack_message_exception(mock_slack, mock_sys_exit):
     message = 'mock message'
     Message.send_slack_message(message)

--- a/test/unit/test_pipelines.py
+++ b/test/unit/test_pipelines.py
@@ -29,7 +29,14 @@ def test_initialize_pipeline(mock_open_project_config, mock_update_git_repo, moc
 
 
 @patch('json.loads', return_value={'mock': 'json'})
-def test_open_project_config(mock_webhook):
+def test_open_project_config(mock_json):
+    # We redeclare a basic mock webhook here because os.path.join on Python 3.7 gets
+    # angry with MagicMock objects being passed in
+    mock_webhook = {
+        "repository": {
+            "full_name": "TEST_user/TEST-repo-name",
+        }
+    }
     with patch('builtins.open', mock_open()):
         config = Pipeline.open_project_config(mock_webhook)
 
@@ -40,7 +47,7 @@ def test_open_project_config(mock_webhook):
 def test_open_project_config_not_found(mock_utils_kill, mock_webhook):
     with patch('builtins.open', mock_open()) as mock_file:
         mock_file.side_effect = FileNotFoundError
-        Pipeline.open_project_config(mock_webhook)
+        _ = Pipeline.open_project_config(mock_webhook)
 
         mock_utils_kill.assert_called_once_with(
             f'Error: Harvey could not find a "harvey.json" file in {Global.repo_full_name(mock_webhook)}.', mock_webhook

--- a/test/unit/test_pipelines.py
+++ b/test/unit/test_pipelines.py
@@ -132,15 +132,16 @@ def test_test_pipeline_error(mock_test_stage, mock_utils_kill, mock_webhook):
     mock_utils_kill.assert_called_once()
 
 
+@patch('harvey.stages.DeployStage.run_container_healthcheck', return_value=True)
 @patch('harvey.stages.DeployComposeStage.run')
-def test_deploy_pipeline_compose_success(mock_deploy_stage, mock_webhook):
+def test_deploy_pipeline_compose_success(mock_deploy_stage, mock_run_container_healthcheck, mock_webhook):
     _, _, healthcheck = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT, MOCK_TIME, True)
 
     assert healthcheck is True
     mock_deploy_stage.assert_called_once_with(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
 
-@patch('harvey.stages.DeployStage.run_container_healthcheck')
+@patch('harvey.stages.DeployStage.run_container_healthcheck', return_value=True)
 @patch('harvey.stages.BuildStage.run')
 @patch('harvey.stages.DeployStage.run')
 def test_deploy_pipeline_no_compose_success(

--- a/test/unit/test_stages.py
+++ b/test/unit/test_stages.py
@@ -1,16 +1,16 @@
 import subprocess
 from test.unit.conftest import mock_config  # Remove once fixtures are fixed
 from test.unit.conftest import mock_response_container
+from unittest.mock import patch
 
-import mock
 from harvey.globals import Global
 from harvey.stages import BuildStage, DeployComposeStage, DeployStage
 
 MOCK_OUTPUT = 'mock output'
 
 
-@mock.patch('harvey.images.Image.remove_image')
-@mock.patch('subprocess.check_output')
+@patch('harvey.images.Image.remove_image')
+@patch('subprocess.check_output')
 def test_build_stage_success(mock_subprocess, mock_remove_image, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     _ = BuildStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
@@ -19,30 +19,35 @@ def test_build_stage_success(mock_subprocess, mock_remove_image, mock_webhook):
     mock_subprocess.assert_called_once()
 
 
-@mock.patch('harvey.images.Image.remove_image')
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))  # noqa
-def test_build_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_remove_image, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.images.Image.remove_image')
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))
+def test_build_stage_subprocess_timeout(
+    mock_subprocess, mock_utils_kill, mock_remove_image, mock_project_path, mock_webhook
+):
     _ = BuildStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_remove_image.assert_called_once()
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('harvey.images.Image.remove_image')
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
-def test_build_stage_process_error(mock_subprocess, mock_utils_kill, mock_remove_image, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.images.Image.remove_image')
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))
+def test_build_stage_process_error(
+    mock_subprocess, mock_utils_kill, mock_remove_image, mock_project_path, mock_webhook
+):
     _ = BuildStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_remove_image.assert_called_once()
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('time.sleep', return_value=None)
-@mock.patch('harvey.containers.Container.inspect_container',
-            return_value=mock_response_container(status=200, dead=False, paused=False,
-                                                 restarting=False, running=True))
+@patch('time.sleep', return_value=None)
+@patch(
+    'harvey.containers.Container.inspect_container',
+    return_value=mock_response_container(status=200, dead=False, paused=False, restarting=False, running=True),
+)
 def test_run_container_healthcheck_success(mock_container_json, mock_sleep, mock_webhook):
     healthcheck = DeployStage.run_container_healthcheck(mock_webhook)
 
@@ -50,13 +55,13 @@ def test_run_container_healthcheck_success(mock_container_json, mock_sleep, mock
     assert healthcheck is True
 
 
-@mock.patch('time.sleep', return_value=None)
-@mock.patch('harvey.containers.Container.inspect_container',
-            return_value=mock_response_container(status=500, dead=True, paused=False,
-                                                 restarting=False, running=False))
+@patch('time.sleep', return_value=None)
+@patch(
+    'harvey.containers.Container.inspect_container',
+    return_value=mock_response_container(status=500, dead=True, paused=False, restarting=False, running=False),
+)
 def test_run_container_healthcheck_failed(mock_container_json, mock_sleep, mock_webhook):
-    """This test checks that if a healthcheck fails, we properly retry
-    """
+    """This test checks that if a healthcheck fails, we properly retry"""
     healthcheck = DeployStage.run_container_healthcheck(mock_webhook)
 
     mock_container_json.assert_called_with(Global.docker_project_name(mock_webhook))
@@ -64,7 +69,7 @@ def test_run_container_healthcheck_failed(mock_container_json, mock_sleep, mock_
     assert healthcheck is False
 
 
-@mock.patch('subprocess.check_output')
+@patch('subprocess.check_output')
 def test_deploy_compose_stage_success(mock_subprocess, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     _ = DeployComposeStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
@@ -72,23 +77,23 @@ def test_deploy_compose_stage_success(mock_subprocess, mock_webhook):
     mock_subprocess.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))  # noqa
-def test_deploy_compose_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))
+def test_deploy_compose_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
     _ = DeployComposeStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('harvey.utils.Utils.kill')
-@mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
+@patch('harvey.utils.Utils.kill')
+@patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))
 def test_deploy_compose_stage_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
     _ = DeployComposeStage.run(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
 
-@mock.patch('subprocess.check_output')
+@patch('subprocess.check_output')
 def test_deploy_compose_stage_custom_compose_success(mock_subprocess, mock_webhook):
     """This test simulates having a custom compose command set in the Harvey config
     file - using two docker-compose files for instance

--- a/test/unit/test_webhooks.py
+++ b/test/unit/test_webhooks.py
@@ -43,10 +43,10 @@ def test_parse_webhook_no_json(mock_start_pipeline):
     assert webhook[1] == 422
 
 
-@mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
-@mock.patch('harvey.webhooks.Webhook.validate_webhook_secret', return_value=False)
-@mock.patch('harvey.globals.Global.APP_MODE', 'prod')
-@mock.patch('harvey.webhooks.Pipeline.start_pipeline')
+@patch('harvey.webhooks.WEBHOOK_SECRET', '123')
+@patch('harvey.webhooks.Webhook.validate_webhook_secret', return_value=False)
+@patch('harvey.globals.Global.APP_MODE', 'prod')
+@patch('harvey.webhooks.Pipeline.start_pipeline')
 def test_parse_webhook_bad_webhook_secret(mock_start_pipeline, mock_webhook_object):
     webhook = Webhook.parse_webhook(mock_webhook_object, False)
 
@@ -57,8 +57,8 @@ def test_parse_webhook_bad_webhook_secret(mock_start_pipeline, mock_webhook_obje
     assert webhook[1] == 403
 
 
-@mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
-@mock.patch('harvey.webhooks.APP_MODE', 'prod')
+@patch('harvey.webhooks.WEBHOOK_SECRET', '123')
+@patch('harvey.webhooks.APP_MODE', 'prod')
 @pytest.mark.skip('Security is hard, revisit later - this logic has been proven in prod')
 def test_validate_webhook_secret(mock_webhook):
     mock_webhook_secret = bytes('123', 'UTF-8')
@@ -68,14 +68,14 @@ def test_validate_webhook_secret(mock_webhook):
     assert validated_webhook_secret is True
 
 
-@mock.patch('harvey.webhooks.WEBHOOK_SECRET', '123')
+@patch('harvey.webhooks.WEBHOOK_SECRET', '123')
 def test_validate_webhook_secret_no_signature(mock_webhook):
     validated_webhook_secret = Webhook.validate_webhook_secret(mock_webhook, None)
 
     assert validated_webhook_secret is False
 
 
-@mock.patch('harvey.globals.Global.FILTER_WEBHOOKS', True)
+@patch('harvey.globals.Global.FILTER_WEBHOOKS', True)
 def test_webhook_originated_outside_github(mock_webhook_object):
     mock_webhook_object.remote_addr = '1.2.3.4'
     webhook = Webhook.parse_webhook(mock_webhook_object, False)

--- a/test/unit/test_webhooks.py
+++ b/test/unit/test_webhooks.py
@@ -1,12 +1,12 @@
 import hashlib
+from unittest.mock import MagicMock, patch
 
-import mock
 import pytest
 from harvey.webhooks import Webhook
 
 
-@mock.patch('harvey.globals.Global.APP_MODE', 'test')
-@mock.patch('harvey.webhooks.Pipeline.start_pipeline')
+@patch('harvey.globals.Global.APP_MODE', 'test')
+@patch('harvey.webhooks.Pipeline.start_pipeline')
 def test_parse_webhook(mock_start_pipeline, mock_webhook_object):
     webhook = Webhook.parse_webhook(mock_webhook_object, False)
 
@@ -17,8 +17,8 @@ def test_parse_webhook(mock_start_pipeline, mock_webhook_object):
     assert webhook[1] == 200
 
 
-@mock.patch('harvey.globals.Global.APP_MODE', 'test')
-@mock.patch('harvey.webhooks.Pipeline.start_pipeline')
+@patch('harvey.globals.Global.APP_MODE', 'test')
+@patch('harvey.webhooks.Pipeline.start_pipeline')
 def test_parse_webhook_bad_branch(mock_start_pipeline, mock_webhook_object):
     webhook = Webhook.parse_webhook(mock_webhook_object(branch='ref/heads/bad_branch'), False)
 
@@ -29,10 +29,10 @@ def test_parse_webhook_bad_branch(mock_start_pipeline, mock_webhook_object):
     assert webhook[1] == 422
 
 
-@mock.patch('harvey.globals.Global.APP_MODE', 'test')
-@mock.patch('harvey.webhooks.Pipeline.start_pipeline')
+@patch('harvey.globals.Global.APP_MODE', 'test')
+@patch('harvey.webhooks.Pipeline.start_pipeline')
 def test_parse_webhook_no_json(mock_start_pipeline):
-    mock_webhook = mock.MagicMock()
+    mock_webhook = MagicMock()
     mock_webhook.json = None
     webhook = Webhook.parse_webhook(mock_webhook, False)
 


### PR DESCRIPTION
* Bumps dependencies (Flask 1 to Flask 2) and now requires Python 3.7. Also removes the `mock` library in favor of the builtin `unittest.mock` library
