### PR TITLE
fix: corrects healthchecks for compose workflows (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
     * Users can now configure their own comma separated list of `ALLOWED_BRANCHES`
     * Previously a webhook secret was required; now, Harvey will run Pipelines without a webhook secret (bypassing decoding and validation of the previously non-existent secret) if there is no `WEBHOOK_SECRET` variable set
     * Additional refactor surrounding how we validate webhook secrets
-
-* Various code refactors
+* Fixed the container healthcheck when using the compose workflow - this was accomplished by making the compose and non-compose container names uniform
+* Various code refactors and bug fixes
 
 ## v0.12.0 (2021-08-17)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - Harvey will timeout git clone/pull after 180 seconds.
 - Harvey will shallow clone your project with the latest 10 commits.
 - Harvey pulls/clones from the master branch.
+- When using the `compose` workflow, the container and/or service name must match the GitHub repository name exactly (alphanumeric characters only) to pass the healthcheck
 
 ## Harvey Configuration Examples
 

--- a/harvey/pipelines.py
+++ b/harvey/pipelines.py
@@ -136,8 +136,7 @@ class Pipeline:
         if use_compose:
             build = ''  # When using compose, there is no build step
             deploy = DeployComposeStage.run(config, webhook, output)
-            # healthcheck = Stage.run_container_healthcheck(webhook)  # TODO: Correct healthchecks for compose
-            healthcheck = True
+            healthcheck = DeployStage.run_container_healthcheck(webhook)
         else:
             build = BuildStage.run(config, webhook, output)
             deploy = DeployStage.run(webhook, output)

--- a/harvey/stages.py
+++ b/harvey/stages.py
@@ -286,6 +286,7 @@ class DeployStage:
         if container_state and container_state['Running'] is True:
             container_healthy = True
         elif retry_attempt < max_retries:
+            # TODO: This is a great spot for logging what container is failing and what attempt it is
             retry_attempt += 1
             time.sleep(5)
             DeployStage.run_container_healthcheck(webhook, retry_attempt)
@@ -303,6 +304,8 @@ class DeployComposeStage:
         """
         start_time = datetime.now()
         compose = f'-f {config["compose"]}' if config.get('compose') else None
+        # Docker will complete the project name by appending the container_name field and a 1
+        # A full example is something like `harvey_ownername_reponame_1`
         project_name = f'harvey_{Global.repo_owner_name(webhook)}'
 
         # Build the image and container from the docker-compose file

--- a/harvey/stages.py
+++ b/harvey/stages.py
@@ -285,7 +285,6 @@ class DeployStage:
         # We need to explicitly check for a state and a running key here
         if container_state and container_state['Running'] is True:
             container_healthy = True
-            return container_healthy
         elif retry_attempt < max_retries:
             retry_attempt += 1
             time.sleep(5)
@@ -304,12 +303,13 @@ class DeployComposeStage:
         """
         start_time = datetime.now()
         compose = f'-f {config["compose"]}' if config.get('compose') else None
+        project_name = f'harvey_{Global.repo_owner_name(webhook)}'
 
         # Build the image and container from the docker-compose file
         try:
             compose_command = subprocess.check_output(
-                f'cd {os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook))}                 &&'
-                f' docker-compose {compose} up -d --build',
+                f'cd {os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook))}'
+                f' && docker-compose {compose} --project-name {project_name} up -d --build',
                 stdin=None,
                 stderr=None,
                 shell=True,

--- a/test/unit/test_globals.py
+++ b/test/unit/test_globals.py
@@ -40,7 +40,7 @@ def test_repo_commit_id(mock_webhook):
 def test_docker_project_name(mock_webhook):
     result = Global.docker_project_name(mock_webhook)
 
-    assert result == 'test_owner-test-repo-name'
+    assert result == 'harvey_test_owner_test-repo-name_1'
 
 
 def test_github_webhook_ip_ranges():


### PR DESCRIPTION
* Correct the health checks for compose workflows by ensuring a name can either be found via webhook OR via the `container-name` field in a compose file.