### PR TITLE
feat: overhauls the pipeline endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 __pycache__
 .DS_Store
-projects/*
-!projects/Dockerfile
-!projects/.harvey
-logs
 *.json
 !mock_webhook.json
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 * Gracefully handles not being able to find a container or list of containers
 * Shallow clone repos to 1 commit instead of 10
 * Retry pipelines that fail due to local, uncommitted changes present when pulling the repo (closes #38)
+* Now saves projects to `~/harvey/projects` instead of locally to `harvey/projects`
+* Now saves project_logs to `~/harvey/project_logs` instead of locally to `harvey/logs`
+* Adds a check to ensure there is a `docker-compose.yml` file present
+    * Now supports yaml files ending in both `yml` or `yaml`
+* Project logs are now overwritten on each deployment so there is only one log file for each project. This will conserve space as well as reduce complexity of the project when retrieving pipelines via the API
+* Overhauled the response of the `pipelines` endpoint to include a `id`, `updated_at`, and `status` key for each record
 
 ## v0.15.0 (2021-11-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     * Now supports yaml files ending in both `yml` or `yaml`
 * Project logs are now overwritten on each deployment so there is only one log file for each project. This will conserve space as well as reduce complexity of the project when retrieving pipelines via the API
 * Overhauled the response of the `pipelines` endpoint to include a `id`, `updated_at`, and `status` key for each record
+* Fixed various path bugs that wouldn't resolve properly on Windows (used `os.path.join()`)
 
 ## v0.15.0 (2021-11-13)
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Harvey's entrypoint (eg: `127.0.0.1:5000/pipelines/start`) accepts a webhook fro
     "name": "justinpaulhammond",
     "full_name": "Justintime50/justinpaulhammond",
     "url": "https://github.com/Justintime50/justinpaulhammond",
-    "ssh_url": "git@github.com:Justintime50/justinpaulhammond.git"
-  },
-  "owner": {
-    "name": "Justintime50"
+    "ssh_url": "git@github.com:Justintime50/justinpaulhammond.git",
+    "owner": {
+      "name": "Justintime50"
+    }
   },
   "commits": [
     {
@@ -124,7 +124,6 @@ Harvey's entrypoint (eg: `127.0.0.1:5000/pipelines/start`) accepts a webhook fro
     "pipeline": "deploy"
   }
 }
-
 ```
 
 ### App Configuration
@@ -155,8 +154,8 @@ venv/bin/python examples/examples.py
 # Retrieve a list of pipelines
 curl -X GET http://127.0.0.1:5000/pipelines
 
-# Retrieve the pipeline output from Harvey using a commit ID.
-curl -X GET http://127.0.0.1:5000/pipeline/f599cde2f2a0ad562bb7982328fe0aeee9d22b1c
+# Retrieve a pipeline log from Harvey using the full repo name
+curl -X GET http://127.0.0.1:5000/pipelines/justintime50/justinpaulhammond
 ```
 
 ## Development

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,29 +1,36 @@
 # flake8: noqa
 import json
 
-import harvey
 import requests
 
-"""API Entrypoint (Webhook)"""
-with open('examples/git_webhook.json', 'r') as file:
-    data = json.load(file)
-    request = requests.post(
-        'http://127.0.0.1:5000/pipelines/start',
-        json=data,
-        headers={
-            'Content-Type': 'application/json',
-        },
-    )
-    print(request.json())
+import harvey
+
+# """API Entrypoint (Webhook)"""
+# with open('examples/git_webhook.json', 'r') as file:
+#     data = json.load(file)
+#     request = requests.post(
+#         'http://127.0.0.1:5000/pipelines/start',
+#         json=data,
+#         headers={
+#             'Content-Type': 'application/json',
+#         },
+#     )
+#     print(request.json())
 
 # """Retrieve a Pipeline by ID"""
 # request = requests.get(
-#     'http://127.0.0.1:5000/pipelines/f599cde2f2a0ad562bb7982328fe0aeee9d22b1c',
-#     headers={'Content-Type': 'application/json',}
+#     'http://127.0.0.1:5000/pipelines/test_owner-test-repo-name',
+#     headers={
+#         'Content-Type': 'application/json',
+#     },
 # )
 # print(request.text)
 
-# """Retrieve all pipelines"""
-# request = requests.get(
-#     'http://127.0.0.1:5000/pipelines', headers={'Content-Type': 'application/json',})
-# print(request.text)
+"""Retrieve all pipelines"""
+request = requests.get(
+    'http://127.0.0.1:5000/pipelines',
+    headers={
+        'Content-Type': 'application/json',
+    },
+)
+print(request.text)

--- a/harvey/app.py
+++ b/harvey/app.py
@@ -86,6 +86,9 @@ def retrieve_pipelines():
 
     for root, dirs, files in os.walk(Global.PROJECTS_LOG_PATH, topdown=True):
         for filename in files:
+            # Skip the macOS meta directory file
+            if filename == '.DS_Store':
+                continue
             full_file_path = os.path.join(root, filename)
             last_run = datetime.datetime.strptime(time.ctime(os.path.getmtime(full_file_path)), '%c')
             log_file = filename.split('.')[0]

--- a/harvey/containers.py
+++ b/harvey/containers.py
@@ -10,15 +10,11 @@ from harvey.utils import LOGGER_NAME, Utils
 class Container:
     @staticmethod
     def create_client():
-        """Creates a Docker client to use for connections.
-
-        TODO: Be aware that invoking this multiple times for different processes will open multiple
-        connections at once, there is probably some optimizations we can/should make with this.
-        """
+        """Creates a Docker client to use for connections."""
         logger = woodchips.get(LOGGER_NAME)
 
         logger.debug('Setting up Docker client...')
-        client = docker.from_env(timeout=30)  # TODO: Allow this to be configurable
+        client = docker.from_env(timeout=30)
 
         return client
 
@@ -48,7 +44,7 @@ class Container:
         logger.debug('Listing containers...')
 
         try:
-            containers = client.containers.list(limit=100)  # TODO: Allow this to be configurable
+            containers = client.containers.list(limit=100)
         except docker.errors.APIError:
             # If the Docker API errors, fail gracefully with an empty list
             containers = []

--- a/harvey/globals.py
+++ b/harvey/globals.py
@@ -14,8 +14,8 @@ class Global:
     HARVEY_LOG_PATH = 'logs/harvey'
     # TODO: Is there a way to sync this with `setup.py`? (short answer: not easily since you can't import this there)
     HARVEY_VERSION = '0.15.0'
-    PROJECTS_LOG_PATH = 'logs/projects'
-    PROJECTS_PATH = 'projects'
+    PROJECTS_LOG_PATH = os.path.expanduser('~/harvey/project_logs')
+    PROJECTS_PATH = os.path.expanduser('~/harvey/projects')
     SLACK = os.getenv('SLACK')
     SUPPORTED_PIPELINES = {
         'deploy',

--- a/harvey/globals.py
+++ b/harvey/globals.py
@@ -14,8 +14,8 @@ class Global:
     HARVEY_LOG_PATH = os.path.join('logs', 'harvey')
     # TODO: Is there a way to sync this with `setup.py`? (short answer: not easily since you can't import this there)
     HARVEY_VERSION = '0.15.0'
-    PROJECTS_LOG_PATH = os.path.expanduser(os.path.join('~', 'harvey', 'project_logs'))
-    PROJECTS_PATH = os.path.expanduser(os.path.join('~', 'harvey', 'projects'))
+    PROJECTS_LOG_PATH = os.path.expanduser('~/harvey/project_logs')
+    PROJECTS_PATH = os.path.expanduser('~/harvey/projects')
     SLACK = os.getenv('SLACK')
     SUPPORTED_PIPELINES = {
         'deploy',

--- a/harvey/globals.py
+++ b/harvey/globals.py
@@ -11,11 +11,11 @@ class Global:
     ALLOWED_BRANCHES = [branch.strip().lower() for branch in os.getenv('ALLOWED_BRANCHES', 'main,master').split(',')]
     DEPLOY_TIMEOUT = 1800  # 30 minutes
     GIT_TIMEOUT = 300  # 5 minutes
-    HARVEY_LOG_PATH = 'logs/harvey'
+    HARVEY_LOG_PATH = os.path.join('logs', 'harvey')
     # TODO: Is there a way to sync this with `setup.py`? (short answer: not easily since you can't import this there)
     HARVEY_VERSION = '0.15.0'
-    PROJECTS_LOG_PATH = os.path.expanduser('~/harvey/project_logs')
-    PROJECTS_PATH = os.path.expanduser('~/harvey/projects')
+    PROJECTS_LOG_PATH = os.path.expanduser(os.path.join('~', 'harvey', 'project_logs'))
+    PROJECTS_PATH = os.path.expanduser(os.path.join('~', 'harvey', 'projects'))
     SLACK = os.getenv('SLACK')
     SUPPORTED_PIPELINES = {
         'deploy',

--- a/harvey/pipelines.py
+++ b/harvey/pipelines.py
@@ -233,7 +233,7 @@ class Pipeline:
             logger.error(final_output)
             Utils.kill(final_output, webhook)
         except subprocess.CalledProcessError:
-            final_output = f'{output}Harvey could not finish the deploy.'
+            final_output = f'{output}\nHarvey could not finish the deploy.'
             logger.error(final_output)
             Utils.kill(final_output, webhook)
 

--- a/harvey/pipelines.py
+++ b/harvey/pipelines.py
@@ -164,35 +164,60 @@ class Pipeline:
         start_time = datetime.now()
 
         repo_path = os.path.join(Global.PROJECTS_PATH, Global.repo_full_name(webhook))
-        # TODO: This is sad for `docker-compose.yaml` files containing an "a", allow for both
-        default_compose_filepath = os.path.join(repo_path, 'docker-compose.yml')
-        prod_compose_filepath = os.path.join(repo_path, 'docker-compose-prod.yml')
+
+        docker_compose_yml = 'docker-compose.yml'
+        docker_compose_yaml = 'docker-compose.yaml'
+        docker_compose_prod_yml = 'docker-compose-prod.yml'
+        docker_compose_prod_yaml = 'docker-compose-prod.yaml'
+
+        # Setup the `docker-compose.yml` file for all deployments
+        if os.path.exists(os.path.join(repo_path, docker_compose_yml)):
+            default_compose_filepath = os.path.join(repo_path, docker_compose_yml)
+        elif os.path.exists(os.path.join(repo_path, docker_compose_yaml)):
+            default_compose_filepath = os.path.join(repo_path, docker_compose_yaml)
+        else:
+            final_output = f'Harvey could not find a "docker-compose.yml" file in {Global.repo_full_name(webhook)}.'
+            logger.error(final_output)
+            Utils.kill(final_output, webhook)
+
+        if config.get('prod_compose'):
+            # If this is a prod deployment, setup the `docker-compose-prod.yml` file
+            # in addition to the base `docker-compose.yml` file
+            if os.path.exists(os.path.join(repo_path, docker_compose_prod_yml)):
+                prod_compose_filepath = os.path.join(repo_path, docker_compose_prod_yml)
+            elif os.path.exists(os.path.join(repo_path, docker_compose_prod_yaml)):
+                prod_compose_filepath = os.path.join(repo_path, docker_compose_prod_yaml)
+            else:
+                final_output = (
+                    f'Harvey could not find a "docker-compose-prod.yml" file in {Global.repo_full_name(webhook)}.'
+                )
+                logger.error(final_output)
+                Utils.kill(final_output, webhook)
+
+            # fmt: off
+            compose_command = [
+                'docker',
+                'compose',
+                '-f', default_compose_filepath,
+                '-f', prod_compose_filepath,
+                'up', '-d',
+                '--build',
+                '--quiet-pull',
+            ]
+            # fmt: on
+        else:
+            # fmt: off
+            compose_command = [
+                'docker',
+                'compose',
+                '-f', default_compose_filepath,
+                'up', '-d',
+                '--build',
+                '--quiet-pull',
+            ]
+            # fmt: on
 
         try:
-            if config.get('prod_compose'):
-                # fmt: off
-                compose_command = [
-                    'docker',
-                    'compose',
-                    '-f', default_compose_filepath,
-                    '-f', prod_compose_filepath,
-                    'up', '-d',
-                    '--build',
-                    '--quiet-pull',
-                ]
-                # fmt: on
-            else:
-                # fmt: off
-                compose_command = [
-                    'docker',
-                    'compose',
-                    '-f', default_compose_filepath,
-                    'up', '-d',
-                    '--build',
-                    '--quiet-pull',
-                ]
-                # fmt: on
-
             compose_output = subprocess.check_output(
                 compose_command,
                 stdin=None,

--- a/harvey/utils.py
+++ b/harvey/utils.py
@@ -9,6 +9,7 @@ from harvey.messages import Message
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()
 LOGGER_NAME = 'harvey'
+LOG_LOCATION = os.path.expanduser(os.path.join('~', 'harvey', 'logs'))
 
 
 class Utils:
@@ -82,4 +83,4 @@ def setup_logger():
 
     # TODO: We should be able to prepend every logged message with the name of the repo for easy organization and
     # searching of log files
-    logger.log_to_file(location=os.path.expanduser('~/harvey/logs'))
+    logger.log_to_file(location=LOG_LOCATION)

--- a/harvey/utils.py
+++ b/harvey/utils.py
@@ -12,7 +12,6 @@ LOGGER_NAME = 'harvey'
 
 
 class Utils:
-    # TODO: None of these need this class or get anything from it, let's flatten these utilities as needed
     @staticmethod
     def kill(final_output: str, webhook: Dict[str, Any]):
         """A kill util to write everything to logs, send messages,
@@ -20,11 +19,14 @@ class Utils:
         """
         logger = woodchips.get(LOGGER_NAME)
 
-        Utils.generate_pipeline_logs(final_output, webhook)
-        logger.warning(f'{Global.repo_full_name(webhook)} pipeline failed!')
+        failure_message = f'{Global.repo_full_name(webhook)} pipeline failed!'
+        logger.warning(failure_message)
+
+        pipeline_logs = final_output + failure_message
+        Utils.generate_pipeline_logs(pipeline_logs, webhook)
 
         if Global.SLACK:
-            Message.send_slack_message(final_output)
+            Message.send_slack_message(pipeline_logs)
 
         # Close the thread safely
         sys.exit()
@@ -34,32 +36,38 @@ class Utils:
         """Log output and send message on pipeline success."""
         logger = woodchips.get(LOGGER_NAME)
 
-        Utils.generate_pipeline_logs(final_output, webhook)
-        logger.info(f'{Global.repo_full_name(webhook)} pipeline succeeded!')
+        success_message = f'{Global.repo_full_name(webhook)} pipeline succeeded!'
+        logger.info(success_message)
+
+        pipeline_logs = final_output + success_message
+        Utils.generate_pipeline_logs(pipeline_logs, webhook)
 
         if Global.SLACK:
-            Message.send_slack_message(final_output)
+            Message.send_slack_message(pipeline_logs)
 
         # Close the thread safely
         sys.exit()
 
     @staticmethod
     def generate_pipeline_logs(final_output: str, webhook: Dict[str, Any]):
-        """Generate a complete log file with the entire pipeline's output."""
+        """Generate a complete log file with the entire pipeline's output.
+
+        These logs are not to be confused with the internal Harvey `woodchips` logs for the
+        app itself; instead, there is a log file for every project deployed via Harvey that
+        contains the details of the last deploy of that service on the platform.
+        """
         logger = woodchips.get(LOGGER_NAME)
 
         logger.debug(f'Generating pipeline logs for {Global.repo_full_name(webhook)}...')
 
-        pipeline_log_path = os.path.join(Global.PROJECTS_LOG_PATH, Global.repo_full_name(webhook))
-        if not os.path.exists(pipeline_log_path):
-            os.makedirs(pipeline_log_path)
+        project_log_name = f'{Global.repo_owner_name(webhook)}-{Global.repo_name(webhook)}.log'
+        project_log_path = os.path.join(Global.PROJECTS_LOG_PATH, project_log_name)
 
         try:
-            filename = os.path.join(pipeline_log_path, Global.repo_commit_id(webhook) + '.log')
-            with open(filename, 'w') as log:
+            with open(project_log_path, 'w') as log:
                 log.write(final_output)
         except OSError as error:
-            final_output = 'Harvey could not save the log file.'
+            final_output = f'Harvey could not save the log file for {Global.repo_full_name(webhook)}.'
             logger.error(error)
             Utils.kill(final_output, webhook)
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -67,16 +67,17 @@ def mock_output():
 
 @pytest.fixture
 def mock_project_path():
-    mock_project_path = 'projects/test_user/test-repo-name'
+    """This is a partial path, found in the user's home folder."""
+    mock_project_path = 'harvey/projects/test_user/test-repo-name'
 
     return mock_project_path
 
 
 # TODO: Make this fixture work and put it in the `test_build_image` test
-def mock_config(pipeline='deploy', compose=None):
+def mock_config(pipeline='deploy', prod_compose=False):
     mock_config = {
         'pipeline': pipeline,
-        'compose': compose if compose else None,
+        'prod_compose': prod_compose,
     }
 
     return mock_config

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from unittest.mock import patch
 
@@ -9,7 +10,7 @@ from harvey.git import Git
 def test_update_git_repo_path_exists(mock_pull_repo, mock_path_exists, mock_project_path, mock_webhook):  # noqa
     Git.update_git_repo(mock_webhook)
 
-    mock_pull_repo.assert_called_once_with(mock_project_path, mock_webhook)
+    mock_pull_repo.assert_called_once_with(os.path.expanduser(os.path.join('~', mock_project_path)), mock_webhook)
 
 
 @patch('os.path.exists', return_value=False)
@@ -17,7 +18,7 @@ def test_update_git_repo_path_exists(mock_pull_repo, mock_path_exists, mock_proj
 def test_update_git_repo_path_does_not_exist(mock_clone_repo, mock_path_exists, mock_project_path, mock_webhook):
     Git.update_git_repo(mock_webhook)
 
-    mock_clone_repo.assert_called_once_with(mock_project_path, mock_webhook)
+    mock_clone_repo.assert_called_once_with(os.path.expanduser(os.path.join('~', mock_project_path)), mock_webhook)
 
 
 @patch('logging.Logger.debug')

--- a/test/unit/test_pipelines.py
+++ b/test/unit/test_pipelines.py
@@ -88,7 +88,7 @@ def test_run_pipeline_deploy(
 @patch('subprocess.check_output')
 def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
-    _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
+    _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
     mock_subprocess.assert_called_once()
 
@@ -97,7 +97,7 @@ def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
 @patch('harvey.utils.Utils.kill')
 @patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
 def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_webhook):
-    _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
+    _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
@@ -108,7 +108,7 @@ def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_
     'subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd='subprocess.check_output')
 )
 def test_deploy_stage_process_error(mock_subprocess, mock_utils_kill, mock_webhook):  # noqa
-    _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
+    _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
@@ -120,6 +120,6 @@ def test_deploy_stage_prod_compose_success(mock_subprocess, mock_healthcheck, mo
     """This test simulates using the `prod_compose` flag and succeeding."""
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     config = mock_config('deploy', prod_compose=True)
-    _ = Pipeline.deploy(config, mock_webhook, MOCK_OUTPUT)
+    _ = Pipeline.deploy(config, dict(mock_webhook), MOCK_OUTPUT)
 
     mock_subprocess.assert_called_once()

--- a/test/unit/test_pipelines.py
+++ b/test/unit/test_pipelines.py
@@ -86,7 +86,7 @@ def test_run_pipeline_deploy(
 @patch('os.path.exists', return_value=True)
 @patch('harvey.pipelines.Container.run_container_healthcheck', return_value=True)
 @patch('subprocess.check_output')
-def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
+def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_path_exists, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
@@ -96,7 +96,7 @@ def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
 @patch('os.path.exists', return_value=True)
 @patch('harvey.utils.Utils.kill')
 @patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_webhook):
+def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_path_exists, mock_webhook):
     _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
@@ -107,7 +107,7 @@ def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_
 @patch(
     'subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd='subprocess.check_output')
 )
-def test_deploy_stage_process_error(mock_subprocess, mock_utils_kill, mock_webhook):  # noqa
+def test_deploy_stage_process_error(mock_subprocess, mock_utils_kill, mock_path_exists, mock_webhook):  # noqa
     _ = Pipeline.deploy(mock_config('deploy'), dict(mock_webhook), MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
@@ -116,7 +116,7 @@ def test_deploy_stage_process_error(mock_subprocess, mock_utils_kill, mock_webho
 @patch('os.path.exists', return_value=True)
 @patch('harvey.pipelines.Container.run_container_healthcheck', return_value=True)
 @patch('subprocess.check_output')
-def test_deploy_stage_prod_compose_success(mock_subprocess, mock_healthcheck, mock_webhook):
+def test_deploy_stage_prod_compose_success(mock_subprocess, mock_healthcheck, mock_path_exists, mock_webhook):
     """This test simulates using the `prod_compose` flag and succeeding."""
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     config = mock_config('deploy', prod_compose=True)

--- a/test/unit/test_pipelines.py
+++ b/test/unit/test_pipelines.py
@@ -83,41 +83,43 @@ def test_run_pipeline_deploy(
     mock_utils_success.assert_called_once()
 
 
+@patch('os.path.exists', return_value=True)
 @patch('harvey.pipelines.Container.run_container_healthcheck', return_value=True)
 @patch('subprocess.check_output')
-def test_deploy_compose_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
+def test_deploy_stage_success(mock_subprocess, mock_healthcheck, mock_webhook):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
     _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_subprocess.assert_called_once()
 
 
+@patch('os.path.exists', return_value=True)
 @patch('harvey.utils.Utils.kill')
 @patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_deploy_compose_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):
+def test_deploy_stage_subprocess_timeout(mock_subprocess, mock_utils_kill, mock_webhook):
     _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
 
+@patch('os.path.exists', return_value=True)
 @patch('harvey.utils.Utils.kill')
 @patch(
     'subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd='subprocess.check_output')
 )
-def test_deploy_compose_stage_process_error(mock_subprocess, mock_utils_kill, mock_project_path, mock_webhook):  # noqa
+def test_deploy_stage_process_error(mock_subprocess, mock_utils_kill, mock_webhook):  # noqa
     _ = Pipeline.deploy(mock_config('deploy'), mock_webhook, MOCK_OUTPUT)
 
     mock_utils_kill.assert_called_once()
 
 
+@patch('os.path.exists', return_value=True)
 @patch('harvey.pipelines.Container.run_container_healthcheck', return_value=True)
 @patch('subprocess.check_output')
-def test_deploy_compose_stage_custom_compose_success(mock_subprocess, mock_healthcheck, mock_webhook):
-    """This test simulates having a custom compose command set in the Harvey config
-    file - using two docker-compose files for instance
-    """
+def test_deploy_stage_prod_compose_success(mock_subprocess, mock_healthcheck, mock_webhook):
+    """This test simulates using the `prod_compose` flag and succeeding."""
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
-    config = mock_config('deploy', compose='docker-compose.yml -f docker-compose-prod.yml')
+    config = mock_config('deploy', prod_compose=True)
     _ = Pipeline.deploy(config, mock_webhook, MOCK_OUTPUT)
 
     mock_subprocess.assert_called_once()

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,7 +1,7 @@
 import tempfile
 from unittest.mock import mock_open, patch
 
-from harvey.utils import Utils
+from harvey.utils import Utils, setup_logger
 
 
 @patch('harvey.utils.Utils.generate_pipeline_logs')
@@ -53,27 +53,12 @@ def test_success_with_slack(mock_logger, mock_sys_exit, mock_generate_logs, mock
     mock_slack.assert_called_once()
 
 
-@patch('os.makedirs')
 @patch('logging.Logger.debug')
-def test_generate_pipeline_logs(mock_logger, mock_makedirs, mock_output, mock_webhook):
+def test_generate_pipeline_logs(mock_logger, mock_output, mock_webhook):
     with patch('builtins.open', mock_open()):
         Utils.generate_pipeline_logs(mock_output, mock_webhook)
 
         mock_logger.assert_called()
-        mock_makedirs.assert_called_once()
-
-
-@patch('harvey.globals.Global.repo_full_name', return_value='')
-@patch('os.makedirs')
-@patch('logging.Logger.debug')
-def test_generate_pipeline_logs_dir_exists(mock_logger, mock_makedirs, mock_output, mock_webhook):
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with patch('harvey.globals.Global.PROJECTS_LOG_PATH', temp_dir):
-            with patch('builtins.open', mock_open()):
-                Utils.generate_pipeline_logs(mock_output, mock_webhook)
-
-                mock_logger.assert_called()
-                mock_makedirs.assert_not_called()
 
 
 @patch('harvey.utils.Utils.kill')
@@ -86,3 +71,11 @@ def test_generate_pipeline_logs_exception(mock_logger, mock_output, mock_webhook
                 Utils.generate_pipeline_logs(mock_output, mock_webhook)
 
                 mock_logger.assert_called()
+
+
+@patch('woodchips.Logger')
+def test_setup_logger(mock_logger):
+    """Tests that we setup a `woodchips` logger correctly."""
+    setup_logger()
+
+    mock_logger.assert_called_once()


### PR DESCRIPTION
* Now saves projects to `~/harvey/projects` instead of locally to `harvey/projects`
* Now saves project_logs to `~/harvey/project_logs` instead of locally to `harvey/logs`
* Adds a check to ensure there is a `docker-compose.yml` file present
    * Now supports yaml files ending in both `yml` or `yaml`
* Project logs are now overwritten on each deployment so there is only one log file for each project. This will conserve space as well as reduce complexity of the project when retrieving pipelines via the API
* Overhauled the response of the `pipelines` endpoint to include a `id`, `updated_at`, and `status` key for each record
* Fixed various path bugs that wouldn't resolve properly on Windows (used `os.path.join()`)