### PR TITLE
feat: worker concurrency instead of process/threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## NEXT RELEASE
 
 - Bumps `uwsgi` from `2.0.20` to `2.0.21` unlocking Python 3.10 and 3.11 support
+- Changes from process/threads concurrency to dynamic worker concurrency with uwsgi
+- Added timeouts and worker kill commands so Harvey will canabolize itself instead of the OS
 
 ## v0.20.1 (2022-07-26)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint:
 ## prod - Run the service in production
 prod:
 	docker compose -f docker-compose.yml -f docker-compose-prod.yml up -d --build
-	venv/bin/uwsgi --ini uwsgi.ini
+	venv/bin/uwsgi --ini uwsgi.ini --virtualenv venv
 
 ## run - Run the service locally
 run:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,6 +1,15 @@
 version: "3.8"
 services:
   harvey-nginx:
+    deploy:
+      replicas: 2
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: "512M"
+        reservations:
+          cpus: "0.25"
+          memory: "128M"
     labels:
       - "traefik.http.routers.harveyapi.rule=Host(`harveyapi.justinpaulhammond.com`, `www.harveyapi.justinpaulhammond.com`)"
       - "traefik.http.routers.harveyapi.tls=true"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,6 +2,6 @@ version: "3.8"
 services:
   harvey-nginx:
     labels:
-      - "traefik.http.routers.harveyapi.rule=Host(`harveyapi.justinpaulhammond.com`) || Host(`www.harveyapi.justinpaulhammond.com`)"
+      - "traefik.http.routers.harveyapi.rule=Host(`harveyapi.justinpaulhammond.com`, `www.harveyapi.justinpaulhammond.com`)"
       - "traefik.http.routers.harveyapi.tls=true"
       - "traefik.http.routers.harveyapi.tls.certresolver=letsencrypt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - traefik
     labels:
       - traefik.enable=true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 
 networks:
   traefik:

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,8 +4,9 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
-        # TODO: Please note this only works for macOS: https://docs.docker.com/desktop/mac/networking/
+        include uwsgi_params;
+        # TODO: Please note this only works for macOS: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
         # and will require adjusting for your OS.
-        proxy_pass  http://host.docker.internal:5000;
+        proxy_pass http://host.docker.internal:5000;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,9 +4,7 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
-        include uwsgi_params;
-        # TODO: Please note this only works for macOS: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
-        # and will require adjusting for your OS.
+        # This proxy pass only works for Docker Desktop
         proxy_pass http://host.docker.internal:5000;
     }
 }

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -10,7 +10,7 @@ need-app = true
 
 ; concurrency
 enable-threads = true
-cheaper-initial = 5   ; workers to spawn on startup
+cheaper-initial = 2   ; workers to spawn on startup
 cheaper = 2           ; minimum number of workers to go down to
 workers = 10          ; highest number of workers to run
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,20 +1,26 @@
 [uwsgi]
 ; uwsgi setup
-strict = true
 master = true
+memory-report = true
+auto-procname = true
+strict = true
 vacuum = true
 die-on-term = true
 need-app = true
 
 ; concurrency
-processes = 2
-threads = 2
+enable-threads = true
+cheaper-initial = 5   ; workers to spawn on startup
+cheaper = 2           ; minimum number of workers to go down to
+workers = 10          ; highest number of workers to run
 
 ; workers
-max-requests = 200                   ; Restart workers after this many requests
-max-worker-lifetime = 3600           ; Restart workers after this many seconds
-reload-on-rss = 1024                 ; Restart workers after this much resident memory
-worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
+harakiri = 60               ; Restart workers if they have hung on a single request
+max-requests = 500          ; Restart workers after this many requests
+max-worker-lifetime = 3600  ; Restart workers after this many seconds
+reload-on-rss = 1024        ; Restart workers after this much resident memory
+reload-mercy = 3            ; How long to wait before forcefully killing workers
+worker-reload-mercy = 3     ; How long to wait before forcefully killing workers
 
 ; app setup
 protocol = http
@@ -23,4 +29,4 @@ module = wsgi:APP
 
 ; daemonization
 ; TODO: Name processes `harvey` here
-daemonize=/tmp/harvey_daemon.log
+daemonize = /tmp/harvey_daemon.log

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -16,7 +16,7 @@ workers = 10          ; highest number of workers to run
 
 ; workers
 harakiri = 60               ; Restart workers if they have hung on a single request
-max-requests = 500          ; Restart workers after this many requests
+max-requests = 1000         ; Restart workers after this many requests
 max-worker-lifetime = 3600  ; Restart workers after this many seconds
 reload-on-rss = 1024        ; Restart workers after this much resident memory
 reload-mercy = 3            ; How long to wait before forcefully killing workers


### PR DESCRIPTION
- Uses dynamic worker concurrency over process/threads. (closes #67)
- Bumps nginx version
- Uses 2 instances of nginx in prod
- Fixes SAN SSL record