### PR TITLE
chore: adds back support for Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install Dependencies
         run: make install
       - name: Check format
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 REQUIREMENTS = [
-    'docker == 5.0.*',
+    'docker == 6.0.*',
     'flask == 2.*',
     'python-dotenv == 0.20.*',
     'pyyaml == 6.*',
@@ -13,7 +13,7 @@ REQUIREMENTS = [
     'sentry-sdk == 1.7.*',
     'slackclient == 2.*',
     'sqlitedict == 2.0.*',
-    'uwsgi == 2.0.20',  # TODO: v2.0.20 is unsupported on Python 3.10
+    'uwsgi == 2.0.20',
     'woodchips == 0.2.*',
 ]
 
@@ -64,5 +64,5 @@ setuptools.setup(
     entry_points={
         'console_scripts': ['harvey=harvey.app:main'],
     },
-    python_requires='>=3.7, <3.10',  # TODO: Bumps the max to `<4` when uwsgi is compatible with 3.10 again
+    python_requires='>=3.7, <4',
 )


### PR DESCRIPTION
- Bumps Docker from v5 to v6
- Adds back support for Python 3.10 (whatever incompatibilities there were seem to be gone now)